### PR TITLE
Extend lint rule for daemon flags

### DIFF
--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -494,6 +494,31 @@ func TestLinter_Rules(t *testing.T) {
 			wantErr:     false,
 			matches:     0,
 		},
+		{
+			file:        "daemon-flag-no-redirect.yaml",
+			minSeverity: SeverityWarning,
+			want: EvalResult{
+				File: "daemon-flag-no-redirect",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "background-process-without-redirect",
+							Severity: SeverityWarning,
+						},
+						Error: fmt.Errorf("[background-process-without-redirect]: background process missing output redirect: croc relay --daemon (WARNING)"),
+					},
+				},
+			},
+			wantErr: false,
+			matches: 1,
+		},
+		{
+			file:        "daemon-flag-with-redirect.yaml",
+			minSeverity: SeverityWarning,
+			want:        EvalResult{},
+			wantErr:     false,
+			matches:     0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lint/testdata/files/daemon-flag-no-redirect.yaml
+++ b/pkg/lint/testdata/files/daemon-flag-no-redirect.yaml
@@ -1,0 +1,20 @@
+package:
+  name: daemon-flag-no-redirect
+  version: 1.0.0
+  epoch: 0
+  description: Package with daemon flag without redirect
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://test.com/daemon/${{package.version}}.tar.gz
+      expected-sha256: ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269
+test:
+  pipeline:
+    - runs: "croc relay --daemon"
+update:
+  enabled: true

--- a/pkg/lint/testdata/files/daemon-flag-with-redirect.yaml
+++ b/pkg/lint/testdata/files/daemon-flag-with-redirect.yaml
@@ -1,0 +1,20 @@
+package:
+  name: daemon-flag-with-redirect
+  version: 1.0.0
+  epoch: 0
+  description: Package with daemon flag and redirect
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://test.com/daemon/${{package.version}}.tar.gz
+      expected-sha256: ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269
+test:
+  pipeline:
+    - runs: "croc relay --daemon > croc.log 2>&1"
+update:
+  enabled: true


### PR DESCRIPTION
## Summary
- detect daemonize flags and redirection forms in shell commands
- update background process lint rule to use new patterns
- add tests for daemonized commands with and without output redirection

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68655b1222f88322a5e85f478780b4b5