### PR TITLE
Fix background process lint false positive

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -21,13 +21,12 @@ import (
 )
 
 var (
-	daemonFlags = []string{
-		`-d\b`,
-		`--daemon\b`,
-		`--daemonize\b`,
-		`--detach\b`,
-		`-daemon\b`,
-	}
+       daemonFlags = []string{
+               `--daemon\b`,
+               `--daemonize\b`,
+               `--detach\b`,
+               `-daemon\b`,
+       }
 
 	redirPatterns = []string{
 		`>\s*\S+`,

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -512,14 +512,21 @@ func TestLinter_Rules(t *testing.T) {
 			wantErr: false,
 			matches: 1,
 		},
-		{
-			file:        "daemon-flag-with-redirect.yaml",
-			minSeverity: SeverityWarning,
-			want:        EvalResult{},
-			wantErr:     false,
-			matches:     0,
-		},
-	}
+                {
+                        file:        "daemon-flag-with-redirect.yaml",
+                        minSeverity: SeverityWarning,
+                        want:        EvalResult{},
+                        wantErr:     false,
+                        matches:     0,
+                },
+               {
+                       file:        "cut-d-flag.yaml",
+                       minSeverity: SeverityWarning,
+                       want:        EvalResult{},
+                       wantErr:     false,
+                       matches:     0,
+               },
+        }
 
 	for _, tt := range tests {
 		t.Run(tt.file, func(t *testing.T) {

--- a/pkg/lint/testdata/files/cut-d-flag.yaml
+++ b/pkg/lint/testdata/files/cut-d-flag.yaml
@@ -1,0 +1,20 @@
+package:
+  name: cut-d-flag
+  version: 1.0.0
+  epoch: 0
+  description: Package using cut -d but not running daemon
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://test.com/cut/${{package.version}}.tar.gz
+      expected-sha256: ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269
+test:
+  pipeline:
+    - runs: "getcap /usr/bin/fping | cut -d ' ' -f2 | grep -q -E '^cap_net_raw=+ep$'"
+update:
+  enabled: true


### PR DESCRIPTION
## Summary
- refine daemon detection regex by removing `-d` flag
- add regression test to ensure `cut -d` does not trigger the background process rule

## Testing
- `go test ./pkg/lint -run TestLint -count=1`
- `go test ./... -count=1`

------
https://chatgpt.com/codex/tasks/task_b_6865630b700483228223a56baaac2664