### PR TITLE
Add linter rule for multiline background processes

### DIFF
--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -495,9 +495,17 @@ var AllRules = func(l *Linter) Rules { //nolint:gocyclo
 						if s.Runs == "" {
 							continue
 						}
-						needsRedirect := reBackgroundProcess.MatchString(s.Runs) || reDaemonProcess.MatchString(s.Runs)
-						if needsRedirect && !reOutputRedirect.MatchString(s.Runs) {
-							return fmt.Errorf("background process missing output redirect: %s", s.Runs)
+						lines := strings.Split(s.Runs, "\n")
+						for i, line := range lines {
+							checkLine := line
+							if strings.Contains(line, "&") && i+1 < len(lines) {
+								checkLine += "\n" + lines[i+1]
+							}
+
+							needsRedirect := reBackgroundProcess.MatchString(checkLine) || reDaemonProcess.MatchString(line)
+							if needsRedirect && !reOutputRedirect.MatchString(line) {
+								return fmt.Errorf("background process missing output redirect: %s", strings.TrimSpace(line))
+							}
 						}
 					}
 					return nil

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -488,6 +488,24 @@ func TestLinter_Rules(t *testing.T) {
 			matches: 1,
 		},
 		{
+			file:        "background-process-multiline-no-redirect.yaml",
+			minSeverity: SeverityWarning,
+			want: EvalResult{
+				File: "background-process-multiline-no-redirect",
+				Errors: EvalRuleErrors{
+					{
+						Rule: Rule{
+							Name:     "background-process-without-redirect",
+							Severity: SeverityWarning,
+						},
+						Error: fmt.Errorf("[background-process-without-redirect]: background process missing output redirect: coredns & (WARNING)"),
+					},
+				},
+			},
+			wantErr: false,
+			matches: 1,
+		},
+		{
 			file:        "background-process-with-redirect.yaml",
 			minSeverity: SeverityWarning,
 			want:        EvalResult{},

--- a/pkg/lint/testdata/files/background-process-multiline-no-redirect.yaml
+++ b/pkg/lint/testdata/files/background-process-multiline-no-redirect.yaml
@@ -1,0 +1,45 @@
+package:
+  name: background-process-multiline-no-redirect
+  version: 1.0.0
+  epoch: 0
+  description: Package with multiline background process without redirect
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: GPL-2.0-only
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://test.com/background/${{package.version}}.tar.gz
+      expected-sha256: ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269
+test:
+  pipeline:
+    - runs: |
+        cat > Corefile <<EOF
+        .:1053 {
+            file /home/build/db.wolfi.dev
+            log
+            errors
+            cache
+        }
+        EOF
+
+        cat > /home/build/db.wolfi.dev <<'EOF'
+        $TTL 3600
+        @    IN SOA ns1.wolfi.dev. admin.wolfi.dev. (
+                  20240101   ; Serial
+                  7200       ; Refresh
+                  3600       ; Retry
+                  1209600    ; Expire
+                  3600 )     ; Negative Cache TTL
+        ;
+        @    IN NS  ns1.wolfi.dev.
+        ;
+        foo.wolfi.dev  IN TXT "hi"
+        EOF
+
+        coredns &
+        sleep 2
+update:
+  enabled: true


### PR DESCRIPTION
## Summary
- improve detection of background processes without redirect by scanning lines individually
- add test case for multiline background process

## Testing
- `go test ./pkg/lint -run TestLinter_Rules/background-process-multiline-no-redirect.yaml -count=1 -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_686563c69cd483228aff571fa2c99df5